### PR TITLE
docs patch - replace use of "examplifies"

### DIFF
--- a/docs/sources/send-data/promtail/_index.md
+++ b/docs/sources/send-data/promtail/_index.md
@@ -45,7 +45,7 @@ drop, and the final metadata to attach to the log line. Refer to the docs for
 Promtail now has native support for ingesting compressed files.
 If a discovered target has decompression configured, Promtail will
 **lazily** decompress the compressed file and push the parsed data to Loki.
-The Promtail configuration below examplifies how to to set up decompression:
+The Promtail configuration example below shows how to to set up decompression:
 
 ```yaml
 server:


### PR DESCRIPTION
minor spelling correction

**What this PR does / why we need it**:
Trivial patch for grammar, updated sentence to match sentence structure used elsewhere in the docs
